### PR TITLE
Collect params.keys in order to improve the speed in mandatory keys check.

### DIFF
--- a/lib/exotel/call.rb
+++ b/lib/exotel/call.rb
@@ -50,8 +50,8 @@ module Exotel
     def valid?(params, options)
       mandatory_keys = [:from, :to, :caller_id, :call_type]
       mandatory_keys << :flow_id if options[:type] == 'flow'
-
-      unless mandatory_keys.all?{|key| params.keys.include?(key)}
+      params_keys = params.keys
+      unless mandatory_keys.all?{|key| params_keys.include?(key)}
         raise Exotel::ParamsError, "Missing one or many required parameters."
       end
       valid_call_type?(params)
@@ -96,6 +96,3 @@ module Exotel
     end
   end
 end
-
-
-


### PR DESCRIPTION
Changes:

- params are converted to keys in a loop.
- It causes an extra operation to convert a hash to an array in a loop.
- Made a change to get keys outside of the loop to improve the
performance.
- Here is the gist showing the speed improvements:
https://gist.github.com/akshaymohite/645bc240888f32469f45c31fcc166740